### PR TITLE
Track PSBT consistency check in type

### DIFF
--- a/bip78/src/sender/error.rs
+++ b/bip78/src/sender/error.rs
@@ -134,6 +134,7 @@ pub struct CreateRequestError(InternalCreateRequestError);
 #[derive(Debug)]
 pub(crate) enum InternalCreateRequestError {
     InvalidOriginalInput(crate::psbt::PsbtInputsError),
+    InconsistentOriginalPsbt(crate::psbt::InconsistentPsbt),
     NoInputs,
     PayeeValueNotEqual,
     NoOutputs,
@@ -151,6 +152,7 @@ impl fmt::Display for CreateRequestError {
 
         match &self.0 {
             InvalidOriginalInput(_) => write!(f, "an input in the original transaction is invalid"),
+            InconsistentOriginalPsbt(_) => write!(f, "the original transaction is inconsistent"),
             NoInputs => write!(f, "the original transaction has no inputs"),
             PayeeValueNotEqual => write!(f, "the value in original transaction doesn't equal value requested in the payment link"),
             NoOutputs => write!(f, "the original transaction has no outputs"),
@@ -170,6 +172,7 @@ impl std::error::Error for CreateRequestError {
 
         match &self.0 {
             InvalidOriginalInput(error) => Some(error),
+            InconsistentOriginalPsbt(error) => Some(error),
             NoInputs => None,
             PayeeValueNotEqual => None,
             NoOutputs => None,

--- a/bip78/src/uri.rs
+++ b/bip78/src/uri.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 use std::convert::TryFrom;
 #[cfg(feature = "sender")]
 use crate::sender;
+#[cfg(feature = "sender")]
+use std::convert::TryInto;
 
 pub struct Uri<'a> {
     pub(crate) address: bitcoin::Address,
@@ -24,8 +26,12 @@ impl<'a> Uri<'a> {
     }
 
     #[cfg(feature = "sender")]
-    pub fn create_request(self, psbt: bitcoin::util::psbt::PartiallySignedTransaction, params: sender::Params) -> Result<(sender::Request, sender::Context), sender::CreateRequestError> {
-        sender::from_psbt_and_uri(psbt, self, params)
+    pub fn create_request(
+        self,
+        psbt: bitcoin::util::psbt::PartiallySignedTransaction,
+        params: sender::Params,
+    ) -> Result<(sender::Request, sender::Context), sender::CreateRequestError> {
+        sender::from_psbt_and_uri(psbt.try_into().map_err(sender::InternalCreateRequestError::InconsistentOriginalPsbt)?, self, params)
     }
 
     pub fn into_static(self) -> Uri<'static> {


### PR DESCRIPTION
This change tracks whether PSBT was verified to be consistent (having
correct counts of inputs and outputs) in type. It moves panic closer to
PSBT construction and it found a possible error - original PSBT is not
guaranteed by the caller to be consistent but we relied on it without
documenting it.

This is an MVP to close #5

@RCasatta what do you think?