### PR TITLE
Remove warnings when all features are set

### DIFF
--- a/bip78/src/fee_rate.rs
+++ b/bip78/src/fee_rate.rs
@@ -5,6 +5,7 @@ use std::ops::{Mul, Div};
 pub(crate) struct FeeRate(u64);
 
 impl FeeRate {
+    #[allow(unused)]
     pub(crate) fn from_sat_per_vb(rate: u64) -> Self {
         FeeRate(rate * 4)
     }
@@ -13,10 +14,12 @@ impl FeeRate {
         FeeRate(rate)
     }
 
+    #[allow(unused)]
     pub(crate) fn to_sat_per_vb(self) -> u64 {
         self.0 * 4
     }
 
+    #[allow(unused)]
     pub(crate) fn to_sat_per_wu(self) -> u64 {
         self.0
     }

--- a/bip78/src/input_type.rs
+++ b/bip78/src/input_type.rs
@@ -5,6 +5,7 @@ use bitcoin::blockdata::transaction::TxOut;
 use bitcoin::util::psbt::Input as PsbtInput;
 
 /// Takes the script out of script_sig assuming script_sig signs p2sh script
+#[allow(unused)]
 fn unpack_p2sh(script_sig: &Script) -> Option<Script> {
     match script_sig.instructions().last()?.ok()? {
         Instruction::PushBytes(bytes) => Some(Script::from(bytes.to_vec())),

--- a/bip78/src/receiver/mod.rs
+++ b/bip78/src/receiver/mod.rs
@@ -1,6 +1,4 @@
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
-use bitcoin::{Script, TxOut};
-use crate::psbt::PsbtExt;
 
 mod error;
 
@@ -16,7 +14,7 @@ pub struct UncheckedProposal {
 }
 
 impl UncheckedProposal {
-    pub fn from_request(body: impl std::io::Read, query: &str, headers: impl Headers) -> Result<Self, RequestError> {
+    pub fn from_request(body: impl std::io::Read, _query: &str, headers: impl Headers) -> Result<Self, RequestError> {
         use crate::bitcoin::consensus::Decodable;
 
         let content_type = headers.get_header("content-type").ok_or(InternalRequestError::MissingHeader("Content-Type"))?;
@@ -80,6 +78,7 @@ impl UnlockedProposal {
 #[must_use = "The transaction must be broadcasted to prevent abuse"]
 pub struct MustBroadcast(pub bitcoin::Transaction);
 
+#[allow(unused)]
 pub struct Proposal {
     psbt: Psbt,
 }
@@ -100,6 +99,7 @@ impl Proposal {
 }
 */
 
+#[allow(unused)]
 pub struct ReceiverOptions {
     dust_limit: bitcoin::Amount,
 }
@@ -109,6 +109,7 @@ pub enum BumpFeePolicy {
     SubtractOurFeeOutput,
 }
 
+#[allow(unused)]
 pub struct NewOutputOptions {
     set_as_fee_output: bool,
     subtract_fees_from_this: bool,

--- a/bip78/src/sender/error.rs
+++ b/bip78/src/sender/error.rs
@@ -24,6 +24,7 @@ pub(crate) enum InternalValidationError {
     SenderTxinContainsFinalScriptWitness,
     TxInContainsKeyPaths,
     ContainsPartialSigs,
+    #[allow(unused)]
     ReceiverTxinNotFinalized,
     ReceiverTxinMissingUtxoInfo,
     MixedSequence,

--- a/bip78/src/sender/mod.rs
+++ b/bip78/src/sender/mod.rs
@@ -301,11 +301,13 @@ impl Context {
 struct OutputStats {
     total_value: bitcoin::Amount,
     contributed_fee: bitcoin::Amount,
+    #[allow(unused)]
     total_weight: Weight,
 }
 
 struct InputStats {
     total_value: bitcoin::Amount,
+    #[allow(unused)]
     total_weight: Weight,
 }
 


### PR DESCRIPTION
Not sure if a lot of `#[allow(unused)]` makes sense, but I would like to build without warnings to avoid missing newly introduced warnings or scrolling up for seeing errors, at least with both receiver and sender features are set