### PR TITLE
Separate job in CI so we can have different MSRV between example and lib

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,12 +4,12 @@ on: [push, pull_request]
 
 jobs:
 
-  test:
+  test-lib:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, nightly, 1.46.0]
+        rust: [stable, nightly, 1.41.1]
 
     steps:
       - uses: actions/checkout@v2
@@ -21,7 +21,22 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --all --all-features --manifest-path bip78/Cargo.toml
+          args: --verbose --all-features --lib --manifest-path bip78/Cargo.toml
+
+  build-payjoin-client:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ stable, nightly, 1.46.0 ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: cd payjoin-client
       - name: build payjoin example
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
By separating the CI job is evident that the library supports rust 1.41.1

close #16 