### PR TITLE
Check Received Proposal with Typestate

### DIFF
--- a/bip78/src/receiver/mod.rs
+++ b/bip78/src/receiver/mod.rs
@@ -1,10 +1,9 @@
-use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
-use bitcoin::{Script, TxOut};
+use bitcoin::{util::psbt::PartiallySignedTransaction as Psbt, AddressType, Script, TxOut};
 
 mod error;
 
-pub use error::RequestError;
 use error::InternalRequestError;
+pub use error::RequestError;
 
 pub trait Headers {
     fn get_header(&self, key: &str) -> Option<&str>;
@@ -14,8 +13,24 @@ pub struct UncheckedProposal {
     psbt: Psbt,
 }
 
+pub struct MaybeInputsOwned {
+    psbt: Psbt,
+}
+
+pub struct MaybeMixedInputScripts {
+    psbt: Psbt,
+}
+
+pub struct MaybeInputsSeen {
+    psbt: Psbt,
+}
+
 impl UncheckedProposal {
-    pub fn from_request(body: impl std::io::Read, query: &str, headers: impl Headers) -> Result<Self, RequestError> {
+    pub fn from_request(
+        body: impl std::io::Read,
+        query: &str,
+        headers: impl Headers,
+    ) -> Result<Self, RequestError> {
         use crate::bitcoin::consensus::Decodable;
 
         let content_type = headers.get_header("content-type").ok_or(InternalRequestError::MissingHeader("Content-Type"))?;
@@ -42,20 +57,89 @@ impl UncheckedProposal {
         })
     }
 
+    /// The Sender's Original PSBT
     pub fn get_transaction_to_check_broadcast(&self) -> bitcoin::Transaction {
         self.psbt.clone().extract_tx()
     }
 
-    pub fn assume_broadcastability_was_verified(self) -> UnlockedProposal {
-        UnlockedProposal {
-            psbt: self.psbt,
-        }
+    /// Call after checking that the Original PSBT can be broadcast.
+    /// 
+    /// Receiver MUST check that the Original PSBT from the sender
+    /// can be broadcast, i.e. `testmempoolaccept` bitcoind rpc returns { "allowed": true,.. }
+    /// for `get_transaction_to_check_broadcast()` before calling this method.
+    ///
+    /// Do this check if you generate bitcoin uri to receive PayJoin on sender request without manual human approval, like a payment processor.
+    /// Such so called "non-interactive" receivers are otherwise vulnerable to probing attacks.
+    /// If a sender can make requests at will, they can learn which bitcoin the receiver owns at no cost.
+    /// Broadcasting the Original PSBT after some time in the failure case makes incurs sender cost and prevents probing.
+    ///
+    /// Call this after checking downstream.
+    pub fn assume_tested_and_scheduled_broadcast(self) -> MaybeInputsOwned {
+        MaybeInputsOwned { psbt: self.psbt }
     }
 
-    pub fn this_is_purely_interactive_wallet(self) -> UnlockedProposal {
-        UnlockedProposal {
-            psbt: self.psbt,
-        }
+    /// Call this method if the only way to initiate a PayJoin with this receiver
+    /// requires manual intervention, as in most consumer wallets.
+    ///
+    /// So-called "non-interactive" receivers, like payment processors, that allow arbitrary requests are otherwise vulnerable to probing attacks.
+    /// Those receivers call `get_transaction_to_check_broadcast()` and `attest_tested_and_scheduled_broadcast()` after making those checks downstream.
+    pub fn assume_interactive_receive_endpoint(self) -> MaybeInputsOwned {
+        MaybeInputsOwned { psbt: self.psbt }
+    }
+}
+
+impl MaybeInputsOwned {
+    /// The receiver should not be able to sign for any of these Original PSBT inputs.
+    /// 
+    /// Check that none of them are owned by the receiver downstream before proceeding.
+    pub fn iter_input_script_pubkeys(&self) -> Vec<Result<&Script, RequestError>> {
+        todo!() // return impl '_ + Iterator<Item = Result<&Script, RequestError>>
+    }
+
+    /// Check that the Original PSBT has no receiver-owned inputs.
+    /// Return original-psbt-rejected error or otherwise refuse to sign undesirable inputs.
+    ///
+    /// An attacker could try to spend receiver's own inputs. This check prevents that.
+    /// Call this after checking downstream.
+    pub fn assume_inputs_not_owned(self) -> MaybeMixedInputScripts {
+        MaybeMixedInputScripts { psbt: self.psbt }
+    }
+}
+
+impl MaybeMixedInputScripts {
+    /// If there is only 1 input type, the receiver should be able to produce the same
+    /// type.
+    ///
+    /// Check downstream before proceeding.
+    pub fn iter_input_script_types(&self) -> Vec<Result<&AddressType, RequestError>> {
+        todo!() // return Iterator<Item = Result<&AddressType, RequestError>>
+    }
+
+    /// Verify the original transaction did not have mixed input types
+    /// Call this after checking downstream.
+    ///
+    /// Note: mixed spends do not necessarily indicate distinct wallet fingerprints.
+    /// This check is intended to prevent some types of wallet fingerprinting.
+    pub fn assume_no_mixed_input_scripts(self) -> MaybeInputsSeen {
+        MaybeInputsSeen { psbt: self.psbt }
+    }
+}
+
+impl MaybeInputsSeen {
+    /// The receiver should not have sent to or received the Original PSBT's inputs before.
+    ///
+    /// Check that these are unknown, never before seen inputs before proceeding.
+    pub fn iter_input_outpoints(&self) -> impl '_ + Iterator<Item=&bitcoin::OutPoint> {
+        self.psbt.global.unsigned_tx.input.iter().map(|input| &input.previous_output)
+    }
+
+    /// Make sure that the original transaction inputs have never been seen before.
+    /// This prevents probing attacks. This prevents reentrant PayJoin, where a sender
+    /// proposes a PayJoin PSBT as a new Original PSBT for a new PayJoin.
+    ///
+    /// Call this after checking downstream.
+    pub fn assume_no_inputs_seen_before(self) -> UnlockedProposal {
+        UnlockedProposal { psbt: self.psbt }
     }
 }
 
@@ -112,4 +196,3 @@ pub struct NewOutputOptions {
     set_as_fee_output: bool,
     subtract_fees_from_this: bool,
 }
-

--- a/bip78/src/receiver/mod.rs
+++ b/bip78/src/receiver/mod.rs
@@ -196,3 +196,58 @@ pub struct NewOutputOptions {
     set_as_fee_output: bool,
     subtract_fees_from_this: bool,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    struct MockHeaders {
+        length: String,
+    }
+
+    impl MockHeaders {
+        #[cfg(test)]
+        fn new(length: u64) -> MockHeaders {
+            MockHeaders { length: length.to_string() }
+        }
+    }
+
+    impl Headers for MockHeaders {
+        fn get_header(&self, key: &str) -> Option<&str> {
+            match key {
+                "content-length" => Some(&self.length),
+                "content-type" => Some("text/plain"),
+                _ => None,
+            }
+        }
+    }
+
+    fn get_proposal_from_test_vector() -> Result<UncheckedProposal, RequestError> {
+
+        // OriginalPSBT Test Vector from BIP
+        // | InputScriptType | Orginal PSBT Fee rate | maxadditionalfeecontribution | additionalfeeoutputindex|
+        // |-----------------|-----------------------|------------------------------|-------------------------|
+        // | P2SH-P2WPKH     |  2 sat/vbyte          | 0.00000182                   | 0                       |
+        let original_psbt = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
+
+        let body = original_psbt.as_bytes();
+        let headers = MockHeaders::new(body.len() as u64);
+        UncheckedProposal::from_request(body, "", headers)
+    }
+
+    #[test]
+    fn can_get_proposal_from_request() {
+        let proposal = get_proposal_from_test_vector();
+        assert!(proposal.is_ok(), "OriginalPSBT should be a valid request");
+    }
+
+    #[test]
+    fn unchecked_proposal_unlocks_after_checks() {
+        let proposal = get_proposal_from_test_vector().unwrap();
+        let unlocked = proposal
+            .assume_tested_and_scheduled_broadcast()
+            .assume_inputs_not_owned()
+            .assume_no_mixed_input_scripts()
+            .assume_no_inputs_seen_before();
+    }
+}


### PR DESCRIPTION
The first patch does Receive Checklist to support sync/async. It uses typestate to guide the downstream wallet through each check in opinionated order. 

The second patch is unit tests

The third patch shares `MockHeaders` in `receiver::test_utils`, since it was used in integration tests too.

closes #26 

All GitHub Actions checks passed: https://github.com/chaincase-app/rust-payjoin/pull/1