### PR TITLE
Check proposal psbt with data methods

### DIFF
--- a/bip78/src/receiver/error.rs
+++ b/bip78/src/receiver/error.rs
@@ -8,6 +8,8 @@ pub(crate) enum InternalRequestError {
     InvalidContentType(String),
     InvalidContentLength(std::num::ParseIntError),
     ContentLengthTooLarge(u64),
+    Psbt(crate::psbt::InconsistentPsbt),
+    PsbtInputs(crate::psbt::PrevTxOutError),
 }
 
 impl From<InternalRequestError> for RequestError {

--- a/bip78/src/receiver/error.rs
+++ b/bip78/src/receiver/error.rs
@@ -10,6 +10,7 @@ pub(crate) enum InternalRequestError {
     ContentLengthTooLarge(u64),
     Psbt(crate::psbt::InconsistentPsbt),
     PsbtInputs(crate::psbt::PrevTxOutError),
+    InputType(crate::input_type::InputTypeError)
 }
 
 impl From<InternalRequestError> for RequestError {

--- a/bip78/src/receiver/mod.rs
+++ b/bip78/src/receiver/mod.rs
@@ -194,3 +194,58 @@ pub struct NewOutputOptions {
     set_as_fee_output: bool,
     subtract_fees_from_this: bool,
 }
+
+mod test {
+    use super::*;
+
+    struct MockHeaders {
+        length: String,
+    }
+
+    impl MockHeaders {
+        #[cfg(test)]
+        fn new(length: u64) -> MockHeaders {
+            MockHeaders { length: length.to_string() }
+        }
+    }
+
+    impl Headers for MockHeaders {
+        fn get_header(&self, key: &str) -> Option<&str> {
+            match key {
+                "content-length" => Some(&self.length),
+                "content-type" => Some("text/plain"),
+                _ => None,
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn get_proposal_from_test_vector() -> Result<UncheckedProposal, RequestError> {
+
+        // OriginalPSBT Test Vector from BIP
+        // | InputScriptType | Orginal PSBT Fee rate | maxadditionalfeecontribution | additionalfeeoutputindex|
+        // |-----------------|-----------------------|------------------------------|-------------------------|
+        // | P2SH-P2WPKH     |  2 sat/vbyte          | 0.00000182                   | 0                       |
+        let original_psbt = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
+
+        let body = original_psbt.as_bytes();
+        let headers = MockHeaders::new(body.len() as u64);
+        UncheckedProposal::from_request(body, "", headers)
+    }
+
+    #[test]
+    fn can_get_proposal_from_request() {
+        let proposal = get_proposal_from_test_vector();
+        assert!(proposal.is_ok(), "OriginalPSBT should be a valid request");
+    }
+
+    #[test]
+    fn unchecked_proposal_unlocks_after_checks() {
+        let proposal = get_proposal_from_test_vector().unwrap();
+        let unlocked = proposal
+            .assume_tested_and_scheduled_broadcast()
+            .assume_inputs_not_owned()
+            .assume_no_mixed_input_scripts()
+            .assume_no_inputs_seen_before();
+    }
+}

--- a/bip78/src/receiver/mod.rs
+++ b/bip78/src/receiver/mod.rs
@@ -1,10 +1,9 @@
-use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
-use bitcoin::{Script, TxOut};
+use bitcoin::{util::psbt::PartiallySignedTransaction as Psbt, AddressType, Script, TxOut};
 
 mod error;
 
-pub use error::RequestError;
 use error::InternalRequestError;
+pub use error::RequestError;
 
 pub trait Headers {
     fn get_header(&self, key: &str) -> Option<&str>;
@@ -14,11 +13,29 @@ pub struct UncheckedProposal {
     psbt: Psbt,
 }
 
+pub struct MaybeInputsOwned {
+    psbt: Psbt,
+}
+
+pub struct MaybeMixedInputScripts {
+    psbt: Psbt,
+}
+
+pub struct MaybeInputsSeen {
+    psbt: Psbt,
+}
+
 impl UncheckedProposal {
-    pub fn from_request(body: impl std::io::Read, query: &str, headers: impl Headers) -> Result<Self, RequestError> {
+    pub fn from_request(
+        body: impl std::io::Read,
+        query: &str,
+        headers: impl Headers,
+    ) -> Result<Self, RequestError> {
         use crate::bitcoin::consensus::Decodable;
 
-        let content_type = headers.get_header("content-type").ok_or(InternalRequestError::MissingHeader("Content-Type"))?;
+        let content_type = headers
+            .get_header("content-type")
+            .ok_or(InternalRequestError::MissingHeader("Content-Type"))?;
         if content_type != "text/plain" {
             return Err(InternalRequestError::InvalidContentType(content_type.to_owned()).into());
         }
@@ -42,20 +59,85 @@ impl UncheckedProposal {
         })
     }
 
+    /// The Sender's Original PSBT
     pub fn get_transaction_to_check_broadcast(&self) -> bitcoin::Transaction {
         self.psbt.clone().extract_tx()
     }
 
-    pub fn assume_broadcastability_was_verified(self) -> UnlockedProposal {
-        UnlockedProposal {
-            psbt: self.psbt,
-        }
+    /// Receiver MUST check that the Original PSBT from the sender
+    /// can be broadcast, i.e. `testmempoolaccept` bitcoind rpc returns { "allowed": true,.. }
+    /// for `get_transaction_to_check_broadcast()` before calling this method.
+    ///
+    /// Do this check if you generate bitcoin uri to receive PayJoin on sender request without manual human approval, like a payment processor.
+    /// Such so called "non-interactive" receivers are otherwise vulnerable to probing attacks.
+    /// If a sender can make requests at will, they can learn which bitcoin the receiver owns at no cost.
+    /// Broadcasting the Original PSBT after some time in the failure case makes incurs sender cost and prevents probing.
+    ///
+    /// Call this after checking downstream.
+    pub fn assume_tested_and_scheduled_broadcast(self) -> MaybeInputsOwned {
+        MaybeInputsOwned { psbt: self.psbt }
     }
 
-    pub fn this_is_purely_interactive_wallet(self) -> UnlockedProposal {
-        UnlockedProposal {
-            psbt: self.psbt,
-        }
+    /// Call this method if the only way to initiate a PayJoin with this receiver
+    /// requires manual intervention, as in most consumer wallets.
+    ///
+    /// So-called "non-interactive" receivers, like payment processors, that allow arbitrary requests are otherwise vulnerable to probing attacks.
+    /// Those receivers call `get_transaction_to_check_broadcast()` and `attest_tested_and_scheduled_broadcast()` after making those checks downstream.
+    pub fn assume_interactive_receive_endpoint(self) -> MaybeInputsOwned {
+        MaybeInputsOwned { psbt: self.psbt }
+    }
+}
+
+impl MaybeInputsOwned {
+    /// The receiver should not be able to sign for any of these Original PSBT inputs.
+    /// Check that none of them are owned by the receiver downstream before proceeding.
+    pub fn iter_input_script_pubkeys(&self) -> Vec<Result<&Script, RequestError>> {
+        todo!() // return impl '_ + Iterator<Item = Result<&Script, RequestError>>
+    }
+
+    /// If the sender included inputs that the receiver could sign for in the original PSBT,
+    /// the receiver must either return error original-psbt-rejected or make sure they do not sign those inputs in the payjoin proposal.
+    ///
+    /// Call this after checking downstream.
+    pub fn assume_inputs_not_owned(self) -> MaybeMixedInputScripts {
+        MaybeMixedInputScripts { psbt: self.psbt }
+    }
+}
+
+impl MaybeMixedInputScripts {
+    /// If there is only 1 input type, the receiver should be able to produce the same
+    /// type.
+    ///
+    /// Check downstream before proceeding.
+    pub fn iter_input_script_types(&self) -> Vec<Result<&AddressType, RequestError>> {
+        todo!() // return Iterator<Item = Result<&AddressType, RequestError>>
+    }
+
+    /// Verify the original transaction did not have mixed input types
+    /// Call this after checking downstream.
+    ///
+    /// Note: mixed spends do not necessarily indicate distinct wallet fingerprints.
+    /// This check is intended to prevent some types of wallet fingerprinting.
+    pub fn assume_no_mixed_input_scripts(self) -> MaybeInputsSeen {
+        MaybeInputsSeen { psbt: self.psbt }
+    }
+}
+
+impl MaybeInputsSeen {
+    /// The receiver should not have sent to or received the Original PSBT's inputs before.
+    ///
+    /// Check that these are unknown, never before seen inputs before proceeding.
+    pub fn iter_input_outpoints(&self) -> impl '_ + Iterator<Item=&bitcoin::OutPoint> {
+        self.psbt.global.unsigned_tx.input.iter().map(|input| &input.previous_output)
+    }
+
+    /// Make sure that the inputs included in the original transaction have never been seen before.
+    /// - This prevents probing attacks.
+    /// - This prevent reentrant payjoin, where a sender attempts to use payjoin transaction as a new original transaction for a new payjoin.
+    ///
+    /// Call this after checking downstream.
+    pub fn assume_no_inputs_seen_before(self) -> UnlockedProposal {
+        UnlockedProposal { psbt: self.psbt }
     }
 }
 
@@ -112,4 +194,3 @@ pub struct NewOutputOptions {
     set_as_fee_output: bool,
     subtract_fees_from_this: bool,
 }
-

--- a/bip78/src/receiver/mod.rs
+++ b/bip78/src/receiver/mod.rs
@@ -195,32 +195,36 @@ pub struct NewOutputOptions {
     subtract_fees_from_this: bool,
 }
 
-mod test {
+pub mod test_util {
     use super::*;
+    use std::collections::HashMap;
 
-    struct MockHeaders {
-        length: String,
-    }
-
-    impl MockHeaders {
-        #[cfg(test)]
-        fn new(length: u64) -> MockHeaders {
-            MockHeaders { length: length.to_string() }
-        }
-    }
+    pub struct MockHeaders(HashMap<String, String>);
 
     impl Headers for MockHeaders {
         fn get_header(&self, key: &str) -> Option<&str> {
-            match key {
-                "content-length" => Some(&self.length),
-                "content-type" => Some("text/plain"),
-                _ => None,
-            }
+            self.0.get(key).map(|e| e.as_str())
         }
     }
 
+    impl MockHeaders {
+        pub fn from_vec(body: &[u8]) -> MockHeaders {
+            let mut h = HashMap::new();
+            h.insert("content-type".to_string(), "text/plain".to_string());
+            h.insert("content-length".to_string(), body.len().to_string());
+            MockHeaders(h)
+        }
+    }
+
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
     #[cfg(test)]
     fn get_proposal_from_test_vector() -> Result<UncheckedProposal, RequestError> {
+        use super::test_util::MockHeaders;
 
         // OriginalPSBT Test Vector from BIP
         // | InputScriptType | Orginal PSBT Fee rate | maxadditionalfeecontribution | additionalfeeoutputindex|
@@ -229,7 +233,7 @@ mod test {
         let original_psbt = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
 
         let body = original_psbt.as_bytes();
-        let headers = MockHeaders::new(body.len() as u64);
+        let headers =  MockHeaders::from_vec(body);
         UncheckedProposal::from_request(body, "", headers)
     }
 

--- a/bip78/tests/integration.rs
+++ b/bip78/tests/integration.rs
@@ -95,6 +95,13 @@ mod integration {
 
         let proposal = proposal.assume_no_inputs_owned();
 
+        // Receive Check 3: receiver does not allow mixed input types
+        for input_type in proposal.iter_input_script_types() {
+            assert!(input_type.unwrap() == bitcoin::AddressType::P2wpkh);
+        }
+
+        let proposal = proposal.assume_no_mixed_input_scripts();
+
         // TODO
     }
 

--- a/bip78/tests/integration.rs
+++ b/bip78/tests/integration.rs
@@ -102,6 +102,13 @@ mod integration {
 
         let proposal = proposal.assume_no_mixed_input_scripts();
 
+        // Receive Check 4: receiver has not seen proposal inputs before
+        for outpoint in proposal.iter_input_outpoints() {
+            assert!(receiver.get_transaction(&outpoint.txid, Some(true)).is_err());
+        }
+
+        let proposal = proposal.assume_no_inputs_seen_before();
+
         // TODO
     }
 

--- a/bip78/tests/integration.rs
+++ b/bip78/tests/integration.rs
@@ -86,6 +86,15 @@ mod integration {
 
         let proposal = proposal.assume_tested_and_scheduled_broadcast();
 
+        // Receive Check 2: receiver can't sign for proposal inputs
+        for script_i in proposal.iter_input_script_pubkeys() {
+            let address = bitcoin::Address::from_script(script_i.unwrap(), bitcoin::Network::Regtest).unwrap();
+            let address_result = receiver.get_address_info(&address).unwrap();
+            assert!(!address_result.is_mine.unwrap());
+        }
+
+        let proposal = proposal.assume_no_inputs_owned();
+
         // TODO
     }
 

--- a/bip78/tests/integration.rs
+++ b/bip78/tests/integration.rs
@@ -76,6 +76,16 @@ mod integration {
         // Receiver receive payjoin proposal, IRL it will be an HTTP request (over ssl or onion)
         let proposal = bip78::receiver::UncheckedProposal::from_request(req.body.as_slice(), "", headers).unwrap();
 
+        // Receive Check 1: Is Broadcastable
+        let original_tx = proposal.get_transaction_to_check_broadcast();
+        let tx_is_broadcastable = bitcoind.client.test_mempool_accept(&[bitcoin::hashes::hex::ToHex::to_hex(&bitcoin::consensus::encode::serialize(&original_tx))]).unwrap().first().unwrap().allowed;
+        assert!(tx_is_broadcastable);
+
+        // In a payment processor, this is where one would defend against the failure case
+        // e.g. `schedule_broadcast(original_tx, Duration::from_min(2));`
+
+        let proposal = proposal.assume_tested_and_scheduled_broadcast();
+
         // TODO
     }
 

--- a/bip78/tests/integration.rs
+++ b/bip78/tests/integration.rs
@@ -10,6 +10,7 @@ mod integration {
     use log::{debug, log_enabled, Level};
     use std::collections::HashMap;
     use bip78::receiver::Headers;
+    use bip78::receiver::test_util::MockHeaders;
 
     #[test]
     fn integration_test() {
@@ -70,31 +71,13 @@ mod integration {
         debug!("Original psbt: {:#?}", psbt);
         let pj_params = bip78::sender::Params::with_fee_contribution(bip78::bitcoin::Amount::from_sat(10000), None);
         let (req, ctx) = pj_uri.create_request(psbt, pj_params).unwrap();
-        let headers = HeaderMock::from_vec(&req.body);
+        let headers = MockHeaders::from_vec(&req.body);
 
         // Receiver receive payjoin proposal, IRL it will be an HTTP request (over ssl or onion)
         let proposal = bip78::receiver::UncheckedProposal::from_request(req.body.as_slice(), "", headers).unwrap();
 
         // TODO
     }
-
-    struct HeaderMock(HashMap<String, String>);
-
-    impl Headers for HeaderMock {
-        fn get_header(&self, key: &str) -> Option<&str> {
-            self.0.get(key).map(|e| e.as_str())
-        }
-    }
-
-    impl HeaderMock {
-        fn from_vec(body: &[u8]) -> HeaderMock {
-            let mut h = HashMap::new();
-            h.insert("content-type".to_string(), "text/plain".to_string());
-            h.insert("content-length".to_string(), body.len().to_string());
-            HeaderMock(h)
-        }
-    }
-
 
     fn load_psbt_from_base64(mut input: impl std::io::Read) -> Result<Psbt, bip78::bitcoin::consensus::encode::Error> {
         use bip78::bitcoin::consensus::Decodable;


### PR DESCRIPTION
Depends on #27 , fix #26. Depends on #32 to run the integration test.

These methods pass data downstream to do receiver checks before advancing typestate.

Relevant integration test checks are implemented for each.

---

The `MaybeMixedInputScripts` check  #3 is the most controversial, and so do I expect its data method to be.

`iter_input_script_types(&self)` relies on psbt helper methods. Those methods use `InputType`. I believe `InputType` was candidate for rust-bitcoin when it was introduced in 2021. However, the helper methods may benefit from being re-implemented to just `AddressType` since the downstream software will likely use rust-bitcoin as a dependency anyhow.

`InputType::P2pk` has no corresponding AddressType, but I don't believe any of our target software would want to produce P2pk outputs or match it as an input. Bitcoind does mixed spends anyway.
`AddressType::Taproot` is available for `InputType::Taproot` in rust-bitcoin v0.28