### PR TITLE
Check !content_type.starts_with("text/plain")

### DIFF
--- a/bip78/src/receiver/mod.rs
+++ b/bip78/src/receiver/mod.rs
@@ -19,7 +19,7 @@ impl UncheckedProposal {
         use crate::bitcoin::consensus::Decodable;
 
         let content_type = headers.get_header("content-type").ok_or(InternalRequestError::MissingHeader("Content-Type"))?;
-        if content_type != "text/plain" {
+        if !content_type.starts_with("text/plain") {
             return Err(InternalRequestError::InvalidContentType(content_type.to_owned()).into());
         }
         let content_length = headers


### PR DESCRIPTION
[Content Type Spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type)'s *media aka MIME type* has to be `"text/plain"`, but a valid Content-Type header could be `text/plain; charset=UTF-8` as in wasabi's request

Even the bip78 spec says "with text/plain *in* the Content-Type HTTP header"