### PR TITLE
Update Readme checklist

### DIFF
--- a/bip78/README.md
+++ b/bip78/README.md
@@ -19,8 +19,8 @@ Please at least review the code that verifies there's no overpayment and let me 
 - [x] Fee contribution support
 - [x] Example client using bitcoind
 - [x] Tested and works with BTCPayServer
-- [ ] Tested and works with WasabiWallet
-- [ ] Minimum fee rate enforcement
+- [ ] Tested and works with JoinMarket
+- [x] Minimum fee rate enforcement
 - [ ] Independent review
 - [ ] Independent testing
 


### PR DESCRIPTION
Wasabi cannot receive PayJoins. JoinMarket does.

Min fee enforcement needs to be tested, but it is implemented here: https://github.com/Kixunil/payjoin/commit/76d334a83c3d4ef87d387cc3ad965525974a2aba